### PR TITLE
Bump v0.1.2 to v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Nigerian Mobile Validator will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2025-05-01
+- Maintenance release to bump v0.1.2 to v0.1.5 (package.json was incorrectly released as v0.1.2)
+- Previous release failed to publish due to workflow rules
+
 ## [0.1.4] - 2025-05-01
 - Maintenance release to bump v0.1.2 to v0.1.4 (package.json was incorrectly released as v0.1.2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nigerian-mobile-validator",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nigerian-mobile-validator",
-            "version": "0.1.4",
+            "version": "0.1.5",
             "license": "MIT",
             "dependencies": {
                 "csv-writer": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nigerian-mobile-validator",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "description": "The most rigorous, up-to-date library for validating Nigerian mobile numbers. Fully NCC-compliant, and security-focused, with enterprise-grade features to prevent the business risks of validation failures in regulated industries.",
     "type": "module",
     "main": "./dist/cjs/index.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=timiagama_nigerian-mobile-validator
 sonar.organization=timiagama
 sonar.projectName=nigerian-mobile-validator
-sonar.projectVersion=0.1.4
+sonar.projectVersion=0.1.5
 
 # SonarCloud URL (do not change)
 sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
- Maintenance release to bump v0.1.2 to v0.1.5 (package.json was incorrectly released as v0.1.2)
- Previous release failed to publish due to workflow rules